### PR TITLE
fix: adjust `MapTo` call to have optional parameter

### DIFF
--- a/src/lib/layout/aem-component.directive.spec.ts
+++ b/src/lib/layout/aem-component.directive.spec.ts
@@ -15,7 +15,7 @@ import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {BrowserDynamicTestingModule} from '@angular/platform-browser-dynamic/testing';
 import {AEMComponentDirective} from './aem-component.directive';
 import {Component, Input} from '@angular/core';
-import {ComponentMapping, MapTo} from './component-mapping';
+import {AbstractMappedComponent, ComponentMapping, MapTo} from './component-mapping';
 import {Utils} from './utils';
 
 @Component({
@@ -35,7 +35,7 @@ class AEMDirectiveTestComponent {
   },
   template: `<div></div>`
 })
-class DirectiveComponent {
+class DirectiveComponent extends AbstractMappedComponent{
   @Input() attr1;
   @Input() attr2;
 

--- a/src/lib/layout/aem-container/aem-container.component.ts
+++ b/src/lib/layout/aem-container/aem-container.component.ts
@@ -13,6 +13,7 @@
 import { Component, Input } from '@angular/core';
 import { Constants } from '../constants';
 import { Utils } from '../utils';
+import {AbstractMappedComponent} from "../component-mapping";
 
 const PLACEHOLDER_CLASS_NAMES = Constants.NEW_SECTION_CLASS_NAMES;
 const PLACEHOLDER_ITEM_NAME = '*';
@@ -30,7 +31,7 @@ const CONTAINER_CLASS_NAMES = 'aem-container';
  * The current component provides the base presentational logic common to containers such as a grid or a page.
  * Container have in common the notion of item holders. Items are represented in the model by the fields _:items_ and _:itemsOrder_
  */
-export class AEMContainerComponent {
+export class AEMContainerComponent extends AbstractMappedComponent{
   /**
    * Map of model items included in the current container
    */

--- a/src/lib/layout/component-mapping.spec.ts
+++ b/src/lib/layout/component-mapping.spec.ts
@@ -1,18 +1,13 @@
 /*
- * ADOBE CONFIDENTIAL
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
  *
- * Copyright 2018 Adobe Systems Incorporated
- * All Rights Reserved.
- *
- * NOTICE:  All information contained herein is, and remains
- * the property of Adobe Systems Incorporated and its suppliers,
- * if any.  The intellectual and technical concepts contained
- * herein are proprietary to Adobe Systems Incorporated and its
- * suppliers and may be covered by U.S. and Foreign Patents,
- * patents in process, and are protected by trade secret or copyright law.
- * Dissemination of this information or reproduction of this material
- * is strictly forbidden unless prior written permission is obtained
- * from Adobe Systems Incorporated.
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
  */
 
 import { ComponentMapping, MapTo, MappedComponentProperties, EditConfig, AbstractMappedComponent } from "./component-mapping";

--- a/src/lib/layout/component-mapping.spec.ts
+++ b/src/lib/layout/component-mapping.spec.ts
@@ -1,30 +1,48 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
- * This file is licensed to you under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License. You may obtain a copy
- * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * ADOBE CONFIDENTIAL
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
- * OF ANY KIND, either express or implied. See the License for the specific language
- * governing permissions and limitations under the License.
+ * Copyright 2018 Adobe Systems Incorporated
+ * All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Adobe Systems Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Adobe Systems Incorporated and its
+ * suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Adobe Systems Incorporated.
  */
 
-import { ComponentMapping, MapTo } from "./component-mapping";
+import { ComponentMapping, MapTo, MappedComponentProperties, EditConfig, AbstractMappedComponent } from "./component-mapping";
+import { Component, Input } from '@angular/core';
+
+
+interface TestProperties extends MappedComponentProperties{
+   some: string;
+}
+
+class ComponentTest1 extends AbstractMappedComponent{
+  @Input() some:string = "defaultValue";
+}
+class ComponentTest2 extends AbstractMappedComponent{
+  @Input() some:string = "otherDefaultValue";
+}
+
 
 describe("Component Mapping", () => {
 
   it("stores configuration", () => {
-    let Component1 = function(){};
-    let Component2 = function() {};
-    let editConfig1 = { some: "1" };
-    let editConfig2 = { some: "2" };
 
-    MapTo("component1")(Component1, editConfig1);
-    MapTo("component2")(Component2, editConfig2);
+    let editConfig1:EditConfig<TestProperties> = { isEmpty: (props) => !!props.some };
+    let editConfig2:EditConfig<TestProperties> = { isEmpty: (props) => !!props.some  };
 
-    expect(ComponentMapping.get("component1")).toBe(Component1);
-    expect(ComponentMapping.get("component2")).toBe(Component2);
+    MapTo<TestProperties>("component1")(ComponentTest1, editConfig1);
+    MapTo<TestProperties>("component2")(ComponentTest2, editConfig2);
+
+    expect(ComponentMapping.get("component1")).toBe(ComponentTest1);
+    expect(ComponentMapping.get("component2")).toBe(ComponentTest2);
     expect(ComponentMapping.getEditConfig("component1")).toBe(editConfig1);
     expect(ComponentMapping.getEditConfig("component2")).toBe(editConfig2);
 

--- a/src/lib/layout/component-mapping.ts
+++ b/src/lib/layout/component-mapping.ts
@@ -1,18 +1,13 @@
 /*
- * ADOBE CONFIDENTIAL
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
  *
- * Copyright 2018 Adobe Systems Incorporated
- * All Rights Reserved.
- *
- * NOTICE:  All information contained herein is, and remains
- * the property of Adobe Systems Incorporated and its suppliers,
- * if any.  The intellectual and technical concepts contained
- * herein are proprietary to Adobe Systems Incorporated and its
- * suppliers and may be covered by U.S. and Foreign Patents,
- * patents in process, and are protected by trade secret or copyright law.
- * Dissemination of this information or reproduction of this material
- * is strictly forbidden unless prior written permission is obtained
- * from Adobe Systems Incorporated.
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
  */
 
 import { ComponentMapping as SPAComponentMapping } from '@adobe/aem-spa-component-mapping';

--- a/src/lib/layout/component-mapping.ts
+++ b/src/lib/layout/component-mapping.ts
@@ -1,27 +1,65 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
- * This file is licensed to you under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License. You may obtain a copy
- * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * ADOBE CONFIDENTIAL
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
- * OF ANY KIND, either express or implied. See the License for the specific language
- * governing permissions and limitations under the License.
+ * Copyright 2018 Adobe Systems Incorporated
+ * All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Adobe Systems Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Adobe Systems Incorporated and its
+ * suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Adobe Systems Incorporated.
  */
 
 import { ComponentMapping as SPAComponentMapping } from '@adobe/aem-spa-component-mapping';
+import {Input, Type} from '@angular/core';
 
 /**
- * The current class extends the @adobe/aem-spa-component-mapping#Mapto library and features with Angular specifics such as
+ * Indicated whether force reload is turned on, forcing the model to be refetched on every MapTo instantiation.
+ */
+export interface ReloadForceAble {
+  cqForceReload?: boolean;
+}
+
+/**
+* MappedComponentProperties
+* Properties given to every component runtime by the SPA editor.
+*/
+export interface MappedComponentProperties extends ReloadForceAble {
+    /*
+    Is the component being viewed in an editor context
+     */
+  isInEditor: boolean;
+    /**
+     * Path to the model associated with the current instance of the component
+     */
+  cqPath: string;
+}
+
+export interface EditConfig<P extends MappedComponentProperties> {
+  emptyLabel?: string;
+  isEmpty(props: P): boolean;
+}
+
+export abstract class AbstractMappedComponent implements MappedComponentProperties{
+  @Input() isInEditor = false;
+  @Input() cqPath = '';
+}
+
+/**
+ * The current class extends the @adobe/cq-spa-component-mapping#Mapto library and features with Angular specifics such as
  *
  * - Storing the editing configurations for each resource type
  */
-export class ComponentMappingWithConfig {
+export class ComponentMappingWithConfig{
   /**
    * Store of EditConfig structures
    */
-  private editConfigMap = {};
+  private editConfigMap : { [key: string]: EditConfig<MappedComponentProperties>; } = {}
 
   constructor(private spaMapping:SPAComponentMapping) {}
 
@@ -31,7 +69,7 @@ export class ComponentMappingWithConfig {
    * @param clazz - Component class to be stored
    * @param [editConfig] - Edit configuration to be stored for the given resource types
    */
-  map(resourceTypes, clazz, editConfig = null) {
+  map<P extends MappedComponentProperties>(resourceTypes, clazz, editConfig:EditConfig<P> = null) {
       let innerClass = clazz;
 
       if (editConfig) {
@@ -44,7 +82,7 @@ export class ComponentMappingWithConfig {
    * Returns the component class for the given resourceType
    * @param resourceType - Resource type for which the component class has been stored
    */
-  get(resourceType) {
+  get(resourceType:string):Type<MappedComponentProperties>{
     return this.spaMapping.get(resourceType);
   }
 
@@ -52,15 +90,15 @@ export class ComponentMappingWithConfig {
    * Returns the EditConfig structure for the given type
    * @param resourceType - Resource type for which the configuration has been stored
    */
-  getEditConfig(resourceType) {
-    return this.editConfigMap[resourceType];
-  }
+  getEditConfig(resourceType:string):EditConfig<MappedComponentProperties> {
+      return this.editConfigMap[resourceType];
+  } 
 }
 
 let componentMapping = new ComponentMappingWithConfig(SPAComponentMapping);
 
-function MapTo(resourceTypes) {
-    return (clazz, editConfig = null) => {
+function MapTo <M extends MappedComponentProperties> (resourceTypes) {
+    return (clazz:Type<M>, editConfig:EditConfig<M> = null) => {
         return componentMapping.map(resourceTypes, clazz, editConfig);
     };
 }

--- a/src/lib/test/mapping.ts
+++ b/src/lib/test/mapping.ts
@@ -1,18 +1,13 @@
 /*
- * ADOBE CONFIDENTIAL
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
  *
- * Copyright 2018 Adobe Systems Incorporated
- * All Rights Reserved.
- *
- * NOTICE:  All information contained herein is, and remains
- * the property of Adobe Systems Incorporated and its suppliers,
- * if any.  The intellectual and technical concepts contained
- * herein are proprietary to Adobe Systems Incorporated and its
- * suppliers and may be covered by U.S. and Foreign Patents,
- * patents in process, and are protected by trade secret or copyright law.
- * Dissemination of this information or reproduction of this material
- * is strictly forbidden unless prior written permission is obtained
- * from Adobe Systems Incorporated.
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
  */
 
 import { MapTo, EditConfig } from "../layout/component-mapping";

--- a/src/lib/test/mapping.ts
+++ b/src/lib/test/mapping.ts
@@ -1,23 +1,33 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
- * This file is licensed to you under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License. You may obtain a copy
- * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * ADOBE CONFIDENTIAL
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
- * OF ANY KIND, either express or implied. See the License for the specific language
- * governing permissions and limitations under the License.
+ * Copyright 2018 Adobe Systems Incorporated
+ * All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Adobe Systems Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Adobe Systems Incorporated and its
+ * suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Adobe Systems Incorporated.
  */
 
-import { MapTo } from "../layout/component-mapping";
+import { MapTo, EditConfig } from "../layout/component-mapping";
 
 import { Component1 } from "./test-comp1.component";
 import { Component2 } from "./test-comp2.component";
 import { Component3 } from "./test-comp3.component";
 import { AEMResponsiveGridComponent } from "../layout/aem-responsivegrid/aem-responsivegrid.component";
+import { TestCompProperties } from './test-comp.type';
 
-MapTo("app/components/comp1")(Component1);
-MapTo("app/components/comp2")(Component2);
-MapTo("app/components/comp3")(Component3);
-MapTo('wcm/foundation/components/responsivegrid')(AEMResponsiveGridComponent);
+const config:EditConfig<TestCompProperties> = {
+    isEmpty: (props) => !! props.title
+};
+
+MapTo<TestCompProperties>("app/components/comp1")(Component1,config);
+MapTo<TestCompProperties>("app/components/comp2")(Component2,config);
+MapTo<TestCompProperties>("app/components/comp3")(Component3,config);
+MapTo<TestCompProperties>('wcm/foundation/components/responsivegrid')(AEMResponsiveGridComponent);

--- a/src/lib/test/test-comp.type.ts
+++ b/src/lib/test/test-comp.type.ts
@@ -1,0 +1,5 @@
+import { MappedComponentProperties } from "../layout/component-mapping";
+
+export interface TestCompProperties extends MappedComponentProperties{
+    title:any;
+}

--- a/src/lib/test/test-comp.type.ts
+++ b/src/lib/test/test-comp.type.ts
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
 import { MappedComponentProperties } from "../layout/component-mapping";
 
 export interface TestCompProperties extends MappedComponentProperties{

--- a/src/lib/test/test-comp1.component.ts
+++ b/src/lib/test/test-comp1.component.ts
@@ -1,18 +1,13 @@
 /*
- * ADOBE CONFIDENTIAL
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
  *
- * Copyright 2018 Adobe Systems Incorporated
- * All Rights Reserved.
- *
- * NOTICE:  All information contained herein is, and remains
- * the property of Adobe Systems Incorporated and its suppliers,
- * if any.  The intellectual and technical concepts contained
- * herein are proprietary to Adobe Systems Incorporated and its
- * suppliers and may be covered by U.S. and Foreign Patents,
- * patents in process, and are protected by trade secret or copyright law.
- * Dissemination of this information or reproduction of this material
- * is strictly forbidden unless prior written permission is obtained
- * from Adobe Systems Incorporated.
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
  */
 
 import { Component, Input } from '@angular/core';

--- a/src/lib/test/test-comp1.component.ts
+++ b/src/lib/test/test-comp1.component.ts
@@ -1,16 +1,22 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
- * This file is licensed to you under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License. You may obtain a copy
- * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * ADOBE CONFIDENTIAL
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
- * OF ANY KIND, either express or implied. See the License for the specific language
- * governing permissions and limitations under the License.
+ * Copyright 2018 Adobe Systems Incorporated
+ * All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Adobe Systems Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Adobe Systems Incorporated and its
+ * suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Adobe Systems Incorporated.
  */
 
 import { Component, Input } from '@angular/core';
+import { AbstractMappedComponent } from '../layout/component-mapping';
 
 @Component({
   selector: 'test-comp1',
@@ -20,8 +26,10 @@ import { Component, Input } from '@angular/core';
   template: `<div>{{ title }}</div>`
 })
 
-export class Component1 {
+export class Component1 extends AbstractMappedComponent{
   @Input() title:any;
 
-  constructor() {}
+  constructor() {
+    super();
+  }
 }

--- a/src/lib/test/test-comp2.component.ts
+++ b/src/lib/test/test-comp2.component.ts
@@ -1,18 +1,13 @@
 /*
- * ADOBE CONFIDENTIAL
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
  *
- * Copyright 2018 Adobe Systems Incorporated
- * All Rights Reserved.
- *
- * NOTICE:  All information contained herein is, and remains
- * the property of Adobe Systems Incorporated and its suppliers,
- * if any.  The intellectual and technical concepts contained
- * herein are proprietary to Adobe Systems Incorporated and its
- * suppliers and may be covered by U.S. and Foreign Patents,
- * patents in process, and are protected by trade secret or copyright law.
- * Dissemination of this information or reproduction of this material
- * is strictly forbidden unless prior written permission is obtained
- * from Adobe Systems Incorporated.
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
  */
 
 import { Component, Input } from '@angular/core';

--- a/src/lib/test/test-comp2.component.ts
+++ b/src/lib/test/test-comp2.component.ts
@@ -1,16 +1,22 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
- * This file is licensed to you under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License. You may obtain a copy
- * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * ADOBE CONFIDENTIAL
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
- * OF ANY KIND, either express or implied. See the License for the specific language
- * governing permissions and limitations under the License.
+ * Copyright 2018 Adobe Systems Incorporated
+ * All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Adobe Systems Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Adobe Systems Incorporated and its
+ * suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Adobe Systems Incorporated.
  */
 
 import { Component, Input } from '@angular/core';
+import { AbstractMappedComponent } from '../layout/component-mapping';
 
 @Component({
   selector: 'test-comp2',
@@ -20,8 +26,10 @@ import { Component, Input } from '@angular/core';
   template: `<div>{{ title }}</div>`
 })
 
-export class Component2 {
+export class Component2 extends AbstractMappedComponent {
   @Input() title:any;
 
-  constructor() {}
+  constructor() {
+    super();
+  }
 }

--- a/src/lib/test/test-comp3.component.ts
+++ b/src/lib/test/test-comp3.component.ts
@@ -1,18 +1,13 @@
 /*
- * ADOBE CONFIDENTIAL
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
  *
- * Copyright 2018 Adobe Systems Incorporated
- * All Rights Reserved.
- *
- * NOTICE:  All information contained herein is, and remains
- * the property of Adobe Systems Incorporated and its suppliers,
- * if any.  The intellectual and technical concepts contained
- * herein are proprietary to Adobe Systems Incorporated and its
- * suppliers and may be covered by U.S. and Foreign Patents,
- * patents in process, and are protected by trade secret or copyright law.
- * Dissemination of this information or reproduction of this material
- * is strictly forbidden unless prior written permission is obtained
- * from Adobe Systems Incorporated.
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
  */
 
 import { Component, Input } from '@angular/core';

--- a/src/lib/test/test-comp3.component.ts
+++ b/src/lib/test/test-comp3.component.ts
@@ -1,16 +1,23 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
- * This file is licensed to you under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License. You may obtain a copy
- * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * ADOBE CONFIDENTIAL
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
- * OF ANY KIND, either express or implied. See the License for the specific language
- * governing permissions and limitations under the License.
+ * Copyright 2018 Adobe Systems Incorporated
+ * All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Adobe Systems Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Adobe Systems Incorporated and its
+ * suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Adobe Systems Incorporated.
  */
 
 import { Component, Input } from '@angular/core';
+import { AbstractMappedComponent } from '../layout/component-mapping';
+import { TestCompProperties } from './test-comp.type';
 
 @Component({
   selector: 'test-comp3',
@@ -20,7 +27,9 @@ import { Component, Input } from '@angular/core';
   template: `<div>{{ title }}</div>`
 })
 
-export class Component3 {
+export class Component3  extends AbstractMappedComponent implements TestCompProperties{
   @Input() title:any;
-  constructor() {}
+  constructor() {
+    super();
+  }
 }


### PR DESCRIPTION
Typed MapTo for angular components.

Does introduce a breaking change :

Mapped Classes need to implement MappedComponentProperties or extend AbstractMappedComponent to be mapped, or a //@ts-ignore must be added.

Also, for MapTo calls that pass a edit config, a generic must be passed:

Old:
`MapTo('core-components-examples/wcm/angular/components/download')(DownloadV1Component, {isEmpty: DownloadV1IsEmptyFn});`

New:
`MapTo<DownloadV1Model & MappedComponentProperties>('core-components-examples/wcm/angular/components/download')(DownloadV1Component, {isEmpty: DownloadV1IsEmptyFn});`

This can be easily bypassed by just introducing any :
`MapTo<any>('core-components-examples/wcm/angular/components/download')(DownloadV1Component, {isEmpty: DownloadV1IsEmptyFn});
`
Or to use ts-ignore.

Therefore the impact is very limited using ts-ignore and the any type. Over time this can be refactored to be properly typed.