### PR TITLE
ci(sonarcloud): adjust config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,5 @@ jobs:
             -Dsonar.organization=adobeinc
             -Dsonar.projectKey=adobe_aem-angular-editable-components
             -Dsonar.sources=src
+            -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
+            -Dsonar.coverage.exclusions=src/public_api.ts,src/test.ts,src/lib/aem-angular-editable-components.module.ts,**/*.spec.ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,18 +11,32 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
           node-version: 12
       - name: Install dependencies
         run: npm ci
-      - name: Run tests and do code coverage check
-        run: npm run test:coverage
       - name: Build the project
         run: npm run build:production
+      - name: Run tests and do code coverage check
+        run: npm run test:coverage
       - name: Upload code coverage report to codecov.io
         uses: codecov/codecov-action@v1
+      - name: Upload Sonar report to sonarcloud.io
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.organization=adobeinc
+            -Dsonar.projectKey=adobe_aem-angular-editable-components
+            -Dsonar.sources=src
+            -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
+            -Dsonar.coverage.exclusions=src/public_api.ts,src/test.ts,src/lib/aem-angular-editable-components.module.ts,**/*.spec.ts
       - name: Release module and publish it in github.com and npmjs.com
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- change the order of steps (first build, then do test coverage, otherwise reports will be deleted)
- checkout repo with full depth (to fully benefit from sonar reports)