### PR TITLE
feature(component-directive): make the component directive extensible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 .scannerwork/
 **/*.log
 *.tgz
+coverage
+.idea

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -29,6 +29,7 @@ const customLaunchers = {
   }
 };
 
+
 module.exports = function(config) {
   config.set({
     basePath: '',

--- a/src/lib/layout/aem-component.directive.custom.spec.ts
+++ b/src/lib/layout/aem-component.directive.custom.spec.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
+import { AEMComponentDirective } from './aem-component.directive';
+import { Component, Input } from '@angular/core';
+import { ComponentMapping, MapTo, LazyMapTo, AbstractMappedComponent } from './component-mapping';
+import { Utils } from './utils';
+import { LazyComponentType } from "../test/lazy-component-wrapper/lazy.component";
+import {CustomDefaultRenderer} from "../test/aem-component-directive/custom-default-renderer";
+import {CustomDirective} from "../test/aem-component-directive/customdirective";
+
+
+
+
+
+@Component({
+  selector: 'test-component',
+  template: `<ng-container CustomDirective [cqItem]='data'></ng-container>`
+})
+class AEMDirectiveTestComponent {
+  @Input() data;
+}
+
+
+
+@Component({
+  selector: 'directive-component',
+  host: {
+    '[attr.attr1]': 'attr1',
+    '[attr.attr2]': 'attr2',
+    '[class]': 'hostClasses'
+  },
+  template: `<div></div>`
+})
+class DirectiveComponent extends AbstractMappedComponent {
+  @Input() attr1;
+  @Input() attr2;
+
+  get hostClasses() {
+    return 'component-class';
+  }
+}
+MapTo<DirectiveComponent>('directive/comp')(DirectiveComponent);
+LazyMapTo<LazyComponentType>('some/lazy/comp')(() => import('../test/lazy-component-wrapper/lazy.component').then((m) => m.LazyComponent));
+
+describe('AEMComponentDirective - Custom', () => {
+
+  const EDIT_CONFIG_EMPTY_LABEL = 'Edit config empty label';
+
+  const TEST_EDIT_CONFIG_EMPTY = {
+    emptyLabel: EDIT_CONFIG_EMPTY_LABEL,
+    isEmpty: () => {
+      return true;
+    }
+  };
+
+  const TEST_EDIT_CONFIG_NOT_EMPTY = {
+    emptyLabel: EDIT_CONFIG_EMPTY_LABEL,
+    isEmpty: function() {
+      return false;
+    }
+  };
+
+  let component: AEMDirectiveTestComponent;
+  let fixture: ComponentFixture<AEMDirectiveTestComponent>;
+
+  let isInEditorSpy;
+  let getEditConfigSpy;
+
+  beforeEach(async(() => {
+    isInEditorSpy = spyOn(Utils, 'isInEditor').and.returnValue(false);
+    getEditConfigSpy = spyOn(ComponentMapping, 'getEditConfig').and.returnValue(undefined);
+
+    TestBed.configureTestingModule({
+      declarations: [ AEMDirectiveTestComponent, DirectiveComponent,CustomDefaultRenderer,CustomDirective, AEMComponentDirective ]
+    }).overrideModule(BrowserDynamicTestingModule, {
+      set: {
+        entryComponents: [ DirectiveComponent,  CustomDefaultRenderer,CustomDirective ]
+      }
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AEMDirectiveTestComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should render the fallback component', async () => {
+    const componentData = {
+      attr1: 'Some value',
+      attr2: 'Another value',
+      ':customType': 'missing/directive/comp'
+    };
+
+    component.data = componentData;
+    fixture.detectChanges();
+
+    await fixture.whenStable();
+
+    const element = fixture.nativeElement;
+    const dynamicElement = element.firstElementChild;
+
+    expect(dynamicElement.innerHTML).toEqual("<div id=\"myCustomComponent\">test</div>")
+  });
+
+
+
+});

--- a/src/lib/layout/aem-component.directive.spec.ts
+++ b/src/lib/layout/aem-component.directive.spec.ts
@@ -106,6 +106,36 @@ describe('AEMComponentDirective', () => {
     expect(dynamicElement.getAttribute('attr1')).toEqual(componentData['attr1']);
     expect(dynamicElement.getAttribute('attr2')).toEqual(componentData['attr2']);
   });
+  it('should not render anything', () => {
+    const componentData = {
+      attr1: 'Some value',
+      attr2: 'Another value',
+      ':type': 'missing/directive/comp'
+    };
+
+    component.data = componentData;
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement;
+    const dynamicElement = element.firstElementChild;
+
+    expect(dynamicElement).toBeNull();
+  });
+  it('should render the fallback component', () => {
+    const componentData = {
+      attr1: 'Some value',
+      attr2: 'Another value',
+      ':type': 'missing/directive/comp'
+    };
+
+    component.data = componentData;
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement;
+    const dynamicElement = element.firstElementChild;
+
+    expect(dynamicElement).toBeNull();
+  });
   it('should correctly pass the inputs for lazy component', async() => {
     const componentData = {
       some: 'Some value',

--- a/src/lib/layout/component-mapping.ts
+++ b/src/lib/layout/component-mapping.ts
@@ -64,12 +64,16 @@ export abstract class AbstractMappedComponent implements MappedComponentProperti
   @Input() itemName = '';
 }
 
+export interface ComponentMappingProvider {
+  get(resourceType:string):Type<unknown>
+  lazyGet(resourceType: string): Promise<Type<unknown>>
+}
 /**
  * The current class extends the @adobe/cq-spa-component-mapping#Mapto library and features with Angular specifics such as
  *
  * - Storing the editing configurations for each resource type
  */
-export class ComponentMappingWithConfig {
+export class ComponentMappingWithConfig implements ComponentMappingProvider{
   /**
    * Store of EditConfig structures
    */

--- a/src/lib/test/aem-component-directive/custom-default-renderer.ts
+++ b/src/lib/test/aem-component-directive/custom-default-renderer.ts
@@ -1,0 +1,14 @@
+import {Component, OnInit} from "@angular/core";
+
+@Component({
+  selector: 'core-contentfragment-default-renderer-v1',
+  template: '<div id="myCustomComponent">test</div>'
+})
+export class CustomDefaultRenderer implements OnInit{
+  ngOnInit(): void {
+    console.log('init?')
+  }
+
+
+
+}

--- a/src/lib/test/aem-component-directive/customdirective.ts
+++ b/src/lib/test/aem-component-directive/customdirective.ts
@@ -1,0 +1,20 @@
+import {AEMComponentDirective} from "../../layout/aem-component.directive";
+import {Directive, Type} from "@angular/core";
+import {ComponentMappingProvider} from "../../layout/component-mapping";
+import {CustomDefaultRenderer} from "./custom-default-renderer";
+import {ComponentMapping} from "@adobe/aem-spa-component-mapping";
+
+@Directive({
+  selector: '[CustomDirective]'
+})
+export class CustomDirective extends AEMComponentDirective {
+
+  getFallbackComponent():Type<unknown> | null{
+    return CustomDefaultRenderer;
+  }
+
+  getType(): string | undefined {
+    return this.cqItem && this.cqItem[":customType"];
+  }
+
+}


### PR DESCRIPTION
## Description

Adding some hooks that can be used to extend the component directive class.
This will enable the content fragment component to reuse this logic instead of duplicating it.

Pending PR : https://github.com/adobe/aem-angular-editable-components/pull/46

## Related Issue

https://github.com/adobe/aem-angular-editable-components/issues/43

## How Has This Been Tested?

Unit tested

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
